### PR TITLE
Enable manual trigger of OpenSSF workflow

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -14,6 +14,7 @@ on:
     - cron: '28 2 * * 4'
   push:
     branches: [ "master" ]
+  workflow_dispatch:
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
Add trigger `workflow_dispatch` to enable manual start of OpenSSF job.